### PR TITLE
Adds Elasticsearch 7.10.2

### DIFF
--- a/elasticsearch710-data/Dockerfile
+++ b/elasticsearch710-data/Dockerfile
@@ -1,0 +1,5 @@
+FROM nfqlt/elasticsearch710
+
+ADD build /build
+CMD exec /build/volume-entrypoint.sh
+

--- a/elasticsearch710-data/Makefile
+++ b/elasticsearch710-data/Makefile
@@ -1,0 +1,1 @@
+../_tools/makefiles/base-data-image-Makefile

--- a/elasticsearch710-data/build.sh
+++ b/elasticsearch710-data/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+stamp="$(date +%s%N)"
+imageName="tmp${stamp}_es_image"
+buildName="tmp${stamp}_es"
+
+cleanup() {
+	set +e
+	rm -f es-data-Dockerfile
+	rm -rf build/helpers
+	rm -f backup.tar
+
+	docker rm -vf "$buildName"
+	docker rmi "$imageName"
+}
+
+trap cleanup EXIT
+
+
+# temporary copy helpers
+cp -r ../../nfqlt/_tools/helpers/ build/helpers
+
+# prepate volume
+sed "s~FROM nfqlt~FROM ${2}nfqlt~" Dockerfile > .Dockerfile
+docker build -f .Dockerfile -t "$imageName" ./
+rm .Dockerfile
+docker run --name "$buildName" -v "$(pwd):/volume" "$imageName"
+
+# create temp dockerfile
+echo -e 'FROM busybox\nADD backup.tar /\nADD build/entrypoint.sh /entrypoint.sh\n' > es-data-Dockerfile
+echo -e 'CMD exec /entrypoint.sh\n' >> es-data-Dockerfile
+
+# build volume image
+docker build -t $1 -f es-data-Dockerfile ./
+

--- a/elasticsearch710-data/build/entrypoint.sh
+++ b/elasticsearch710-data/build/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Non empty trap
+trap "kill -15 $PID" SIGTERM
+
+sleep 2147483647 &
+PID=$!
+
+wait
+

--- a/elasticsearch710-data/build/volume-entrypoint.sh
+++ b/elasticsearch710-data/build/volume-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+/entrypoint.sh &
+esPid=$!
+
+source /build/helpers/common.sh
+
+wait_for_connection "localhost:9200" 30
+wget "localhost:9200/" -O -
+
+# set default shards and replicas
+curl -H 'Content-Type: application/json' -XPUT -d '{"template":"*","settings":{"number_of_shards":2,"number_of_replicas":0}}' http://localhost:9200/_template/default
+sleep 10
+
+kill $esPid
+wait
+
+tar cf /volume/backup.tar /var/elasticsearch/data
+sync
+

--- a/elasticsearch710-data/test/es_data
+++ b/elasticsearch710-data/test/es_data
@@ -1,0 +1,1 @@
+../../_tools/common_tests/es5_data

--- a/elasticsearch710/Dockerfile
+++ b/elasticsearch710/Dockerfile
@@ -1,0 +1,16 @@
+FROM nfqlt/debian-buster
+
+
+VOLUME ["/var/elasticsearch/data"]
+WORKDIR /var/elasticsearch/data
+
+
+EXPOSE 9200
+
+ADD build /build
+RUN bash /build/setup_docker.sh && rm -Rf /build
+
+ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
+
+CMD exec /entrypoint.sh
+

--- a/elasticsearch710/Makefile
+++ b/elasticsearch710/Makefile
@@ -1,0 +1,1 @@
+../_tools/makefiles/base-image-Makefile

--- a/elasticsearch710/README.md
+++ b/elasticsearch710/README.md
@@ -1,0 +1,24 @@
+## elasticsearch 7.10.x
+
+### Sample configuration
+
+```
+version: '2.4'
+services:
+  elasticsearch:
+    image: nfqlt/elasticsearch710
+    ports:
+      - "10.24.0.0:9200:9200"
+    volumes_from:
+      - service:elasticsearchVol:rw
+    environment:
+      NFQ_ENABLE_ELASTIC_MODULES: 'analysis-icu'
+
+
+  elasticsearchVol:
+    image: nfqlt/elasticsearch710-data
+    volumes:
+      - /var/elasticsearch/data
+
+```
+

--- a/elasticsearch710/build/files/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch710/build/files/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,13 @@
+network :
+  host : 0.0.0.0
+
+path:
+  data: /var/elasticsearch/data
+
+http:
+  cors:
+    enabled: true
+    allow-origin: "*"
+
+discovery.type: single-node
+

--- a/elasticsearch710/build/files/entrypoint.sh
+++ b/elasticsearch710/build/files/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+run-parts -v /etc/rc.d
+
+chown -R 1000:1000 /var/elasticsearch
+
+# start es
+exec su project -c /elasticsearch/bin/elasticsearch
+

--- a/elasticsearch710/build/files/etc/rc.d/200-disable-elastic-plugins
+++ b/elasticsearch710/build/files/etc/rc.d/200-disable-elastic-plugins
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+ES_PLUGIN="/elasticsearch/bin/elasticsearch-plugin"
+
+available_plugins=$($ES_PLUGIN list | sed -r 's/[ -]*//')
+
+while read -r plugin; do
+        if [ "$plugin" == "No plugin detected" ]; then
+                continue
+        fi
+        if [ -z "$(echo " $NFQ_ENABLE_ELASTIC_MODULES " | fgrep " $plugin ")" ]; then
+				true
+                #$ES_PLUGIN remove "$plugin" >/dev/null &
+        else
+                echo "++ Enabling plugin: '$plugin'"
+        fi
+done <<< "$available_plugins"
+
+
+for plugin in $NFQ_ENABLE_ELASTIC_MODULES; do
+        if [ -z "$(echo "$available_plugins" | fgrep "$plugin")" ]; then
+                echo "-- WARNING: plugin '$plugin' is not available"
+        fi
+done
+

--- a/elasticsearch710/build/setup_docker.sh
+++ b/elasticsearch710/build/setup_docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# setup
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates-java
+
+ES_PKG_NAME=elasticsearch-7.10.2
+
+cd /tmp/
+wget -nv -t5 -O es.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/$ES_PKG_NAME-linux-x86_64.tar.gz
+tar xzf es.tar.gz
+rm -f es.tar.gz
+mv /tmp/$ES_PKG_NAME /elasticsearch
+cd -
+
+
+# elasticsearch plugins
+es_plugin_install() {
+    for i in {1..5}
+    do
+        /elasticsearch/bin/elasticsearch-plugin install $1 && break || sleep 1
+    done
+}
+es_plugin_install analysis-icu
+
+
+chown -R 1000:1000 /elasticsearch
+
+
+cp -frv /build/files/* / || true
+
+source /usr/local/build_scripts/cleanup_apt.sh
+
+

--- a/elasticsearch710/test/enabling_elastic_modules
+++ b/elasticsearch710/test/enabling_elastic_modules
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CMD="docker run -it -e NFQ_ENABLE_ELASTIC_MODULES $1 run-parts /etc/rc.d"
+
+
+# test enabling analysis-icu module
+export NFQ_ENABLE_ELASTIC_MODULES='analysis-icu'
+$CMD | grep -i 'Enabling plugin.*analysis-icu' &> /dev/null \
+|| (echo "Container did not reported enabling analysis-icu elastic module" && exit -1)
+
+
+

--- a/elasticsearch710/test/starting_in_35000_ms_on_9300_port
+++ b/elasticsearch710/test/starting_in_35000_ms_on_9300_port
@@ -1,0 +1,1 @@
+../../_tools/common_tests/starting_in_x_ms_on_y_port

--- a/elasticsearch710/test/starting_in_40000_ms_on_9200_port
+++ b/elasticsearch710/test/starting_in_40000_ms_on_9200_port
@@ -1,0 +1,1 @@
+../../_tools/common_tests/starting_in_x_ms_on_y_port

--- a/elasticsearch710/test/stopping_in_4000_ms
+++ b/elasticsearch710/test/stopping_in_4000_ms
@@ -1,0 +1,1 @@
+../../_tools/common_tests/stopping_in_x_ms


### PR DESCRIPTION
elasticsearch710 - tests pass
elasticsearch710-data - tests fail with "ls: cannot access '../../nfqlt/_tools/helpers/': No such file or directory"
same failure message is for elasticsearch79-data also