### PR TITLE
Update to fastcgi entrypoint when build dir does not exist

### DIFF
--- a/nginx114/build/files/entrypoint.sh
+++ b/nginx114/build/files/entrypoint.sh
@@ -4,9 +4,11 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-	echo "No fastcgi host found, injecting localhost"
-	echo "127.0.0.1 fastcgi" >> /etc/hosts
+if [ ! -d "/builds/" ]; then
+    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+        echo "No fastcgi host found, injecting localhost"
+        echo "127.0.0.1 fastcgi" >> /etc/hosts
+    fi
 fi
 
 run-parts -v /etc/rc.d

--- a/nginx114/build/files/entrypoint.sh
+++ b/nginx114/build/files/entrypoint.sh
@@ -4,11 +4,9 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if [ ! -d "/builds/" ]; then
-    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-        echo "No fastcgi host found, injecting localhost"
-        echo "127.0.0.1 fastcgi" >> /etc/hosts
-    fi
+if [ ! -d "/builds/" ] && ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+    echo "No fastcgi host found, injecting localhost"
+    echo "127.0.0.1 fastcgi" >> /etc/hosts
 fi
 
 run-parts -v /etc/rc.d

--- a/nginx118/build/files/entrypoint.sh
+++ b/nginx118/build/files/entrypoint.sh
@@ -4,9 +4,11 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-	echo "No fastcgi host found, injecting localhost"
-	echo "127.0.0.1 fastcgi" >> /etc/hosts
+if [ ! -d "/builds/" ]; then
+    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+        echo "No fastcgi host found, injecting localhost"
+        echo "127.0.0.1 fastcgi" >> /etc/hosts
+    fi
 fi
 
 run-parts -v /etc/rc.d

--- a/nginx118/build/files/entrypoint.sh
+++ b/nginx118/build/files/entrypoint.sh
@@ -4,11 +4,9 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if [ ! -d "/builds/" ]; then
-    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-        echo "No fastcgi host found, injecting localhost"
-        echo "127.0.0.1 fastcgi" >> /etc/hosts
-    fi
+if [ ! -d "/builds/" ] && ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+    echo "No fastcgi host found, injecting localhost"
+    echo "127.0.0.1 fastcgi" >> /etc/hosts
 fi
 
 run-parts -v /etc/rc.d

--- a/nginx122/build/files/entrypoint.sh
+++ b/nginx122/build/files/entrypoint.sh
@@ -4,9 +4,11 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-	echo "No fastcgi host found, injecting localhost"
-	echo "127.0.0.1 fastcgi" >> /etc/hosts
+if [ ! -d "/builds/" ]; then
+    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+        echo "No fastcgi host found, injecting localhost"
+        echo "127.0.0.1 fastcgi" >> /etc/hosts
+    fi
 fi
 
 run-parts -v /etc/rc.d

--- a/nginx122/build/files/entrypoint.sh
+++ b/nginx122/build/files/entrypoint.sh
@@ -4,11 +4,9 @@ set -e
 source /tools/functions_init.sh
 
 # for tests when container does not have a link to fastcgi
-if [ ! -d "/builds/" ]; then
-    if ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
-        echo "No fastcgi host found, injecting localhost"
-        echo "127.0.0.1 fastcgi" >> /etc/hosts
-    fi
+if [ ! -d "/builds/" ] && ! fgrep -q fastcgi /etc/hosts && ! host fastcgi; then
+    echo "No fastcgi host found, injecting localhost"
+    echo "127.0.0.1 fastcgi" >> /etc/hosts
 fi
 
 run-parts -v /etc/rc.d


### PR DESCRIPTION
If build directory is found fastcgi checking will be skipped.