### PR TITLE
Fix for linker when multiple projects are running at once.

### DIFF
--- a/linker18ce/build/files/usr/local/bin/container_linker.sh
+++ b/linker18ce/build/files/usr/local/bin/container_linker.sh
@@ -6,7 +6,7 @@ function get_project_name {
 }
 
 function get_project_containers {
-	docker ps --format "{{.Names}}"
+	docker ps --filter "label=com.docker.compose.project=$1" --format "{{.Names}}"
 }
 
 function generate_container_hosts {


### PR DESCRIPTION
The linker will only target containers from the project on which it was launched. 