### PR TITLE
Redis protected-mode disabled by default

### DIFF
--- a/redis70/build/files/etc/redis/redis.conf
+++ b/redis70/build/files/etc/redis/redis.conf
@@ -1,6 +1,6 @@
 bind 0.0.0.0
 
-protected-mode yes
+protected-mode no
 port 6379
 tcp-backlog 511
 timeout 0


### PR DESCRIPTION
Disabled protected mode as it is not needed for our use cases.